### PR TITLE
fix: scroll to top on route navigation (closes #5)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -44,6 +44,12 @@ function AppShell() {
     const location = useLocation();
     const navigate = useNavigate();
 
+
+    // setting here for global usage 
+    useEffect(() => {
+        window.scrollTo(0, 0);  // reset on every route change
+    }, [location.pathname]);
+
     useEffect(() => {
         const handleOAuthParams = async () => {
             const params = new URLSearchParams(location.search);

--- a/client/src/pages/BlogPage.tsx
+++ b/client/src/pages/BlogPage.tsx
@@ -92,6 +92,12 @@ export default function BlogPage() {
     const [isDeletingId, setIsDeletingId] = useState<string | null>(null);
     const { user } = useAuthStore();
 
+
+    // for individual blog page 
+    // useEffect(() =>{
+    //     window.scrollTo(0,0);
+    // }, [postId])
+
     useEffect(() => {
         const fetchBlogData = async () => {
             try {
@@ -158,6 +164,8 @@ export default function BlogPage() {
         };
     }, [postId]);
 
+
+
     useEffect(() => {
         const checkBookmark = async () => {
             if (user) {
@@ -201,6 +209,7 @@ export default function BlogPage() {
         }
     };
 
+    // it hnadles adding comment to the blog post
     const handleAddComment = async (content: string) => {
         if (!user) {
             toast.error('You need to be logged in to comment.');

--- a/client/src/pages/BlogPage.tsx
+++ b/client/src/pages/BlogPage.tsx
@@ -92,12 +92,6 @@ export default function BlogPage() {
     const [isDeletingId, setIsDeletingId] = useState<string | null>(null);
     const { user } = useAuthStore();
 
-
-    // for individual blog page 
-    // useEffect(() =>{
-    //     window.scrollTo(0,0);
-    // }, [postId])
-
     useEffect(() => {
         const fetchBlogData = async () => {
             try {
@@ -164,8 +158,6 @@ export default function BlogPage() {
         };
     }, [postId]);
 
-
-
     useEffect(() => {
         const checkBookmark = async () => {
             if (user) {
@@ -209,7 +201,6 @@ export default function BlogPage() {
         }
     };
 
-    // it hnadles adding comment to the blog post
     const handleAddComment = async (content: string) => {
         if (!user) {
             toast.error('You need to be logged in to comment.');


### PR DESCRIPTION
Fixes #5

When users navigate between pages, the scroll position is now reset to the top.
This provides a better user experience and ensures users always start reading from the beginning of a page.